### PR TITLE
Add some tooltip/tip regarding the usage of generate mailer command

### DIFF
--- a/buffalo/cmd/generate/mailer.go
+++ b/buffalo/cmd/generate/mailer.go
@@ -12,7 +12,7 @@ var mailer = mail.Generator{}
 
 // MailCmd for generating mailers
 var MailCmd = &cobra.Command{
-	Use:   "mailer",
+	Use:   "mailer [name]",
 	Short: "Generates a new mailer for Buffalo",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {


### PR DESCRIPTION
Name was not specified in the usage, while it was for other commands